### PR TITLE
change AllAtomCharges so that {} instead of [] are printed

### DIFF
--- a/dftbplus_step/energy.py
+++ b/dftbplus_step/energy.py
@@ -218,7 +218,9 @@ class Energy(DftbBase):
                             skip = True
                     if not skip:
                         hamiltonian["InitialCharges"] = {
-                            "AllAtomCharges": [*atoms["charge"]]
+                            "AllAtomCharges": "{"
+                            + f"{', '.join(str(c) for c in atoms['charge'])}"
+                            + "}"
                         }
 
                 third_order = P["ThirdOrder"]


### PR DESCRIPTION
I encountered an error while running SEAMM. DFTB+ pointed to the line with the keyword `AllAtomCharges`
 - ` Invalid real value`.

The line it points to is formatted as:

`AllAtomCharges = [value1, value2, value3]`

According to the DFTB+ manual on page 23 (https://dftbplus.org/fileadmin/DFTB-Plus/public/dftb/current/manual.pdf)

The `AllAtomCharges` keyword is followed by curly braces `{value1, value2, value3}`. This PR changes the keyword from being followed with `[]` to `{}`.