### PR TITLE
Fixed issue in band structure with charges.

### DIFF
--- a/dftbplus_step/band_structure.py
+++ b/dftbplus_step/band_structure.py
@@ -109,6 +109,10 @@ class BandStructure(DftbBase):
 
             dftb["KPointsAndWeights"] = self.kpoints(P["nPoints"])
 
+            # Cannot use initial charges when reading charges from file.
+            if "InitialCharges" in dftb:
+                del dftb["InitialCharges"]
+
         result = {
             "Options": {
                 "ReadChargesAsText": "Yes",


### PR DESCRIPTION
The band structure reads the charges from a previous DFTB+ calculation, which causes an error if the charges on the structure are also used. This removes any charges from the input file.