### PR TITLE
Bugfix: initial version of dftbplus.ini

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2024.7.29 -- Bugfix: initial version of dftbplus.ini
+    * The initial version of dftbplus.ini was not generated correctly if it was
+      missing. This caused a crash when running DFTB+.
+
 2024.4.24 -- Finalized support for Docker containers
     * Fixed issues and tested running in containers.
     * Add CI to make a Docker image for DFTB+

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -9,6 +9,7 @@ dependencies:
   # molsystem requires, and only available via Conda.
   - hsd-python
   - seamm
+  - seamm-installer
   - seamm-util
   - tabulate
 


### PR DESCRIPTION
* The initial version of dftbplus.ini was not generated correctly if it was missing. This caused a crash when running DFTB+.